### PR TITLE
Update project to Java 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # spring-practices
-Ejemplos spring
+Ejemplos Spring.
+
+## Requisitos
+
+- Java 21 o superior
 
 
 # Download

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>11</java.version>
+        <!-- Use the latest Java LTS release -->
+        <java.version>21</java.version>
 
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>


### PR DESCRIPTION
## Summary
- require Java 21 in README
- use Java 21 for Maven builds

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850beac3f64832e93eda4455bc091e9